### PR TITLE
Python 3 compatibility

### DIFF
--- a/CloseableQueue.py
+++ b/CloseableQueue.py
@@ -184,12 +184,12 @@ def dequeue(q, getargs={}, on_empty='stop'):
         while True:
             yield q.get(**getargs)
     except Closed:
-        raise StopIteration
+        return
     except Empty:
         if on_empty == 'raise':
             raise
         elif on_empty == 'stop':
-            raise StopIteration
+            return
         else:
             yield on_empty
 

--- a/CloseableQueue.py
+++ b/CloseableQueue.py
@@ -1,7 +1,11 @@
 """Defines the CloseableQueue class and the Close exception class."""
 
-from Queue import Empty, Full, _time
-import Queue as _Queue
+try:
+    from queue import Empty, Full, time as _time
+    import queue as _Queue
+except ImportError:
+    from Queue import Empty, Full, _time
+    import Queue as _Queue
 
 class Closed(Exception):
     """Exception raised by CloseableQueue.put/get on a closed queue."""

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -14,8 +14,8 @@ taken from Python 2.6.5's ``test`` regression tests module.
 """
 from CloseableQueue import CloseableQueue, Closed
 from CloseableQueue import CloseableLifoQueue, CloseablePriorityQueue
-from test_queue import BlockingTestMixin, BaseQueueTest
-from test_queue import FailingQueue, FailingQueueTest
+from .test_queue import BlockingTestMixin, BaseQueueTest
+from .test_queue import FailingQueue, FailingQueueTest
 import unittest
 
 # Because the method queue_test.BaseQueueTest.simple_queue_test
@@ -64,12 +64,12 @@ class FailingCloseableQueue(CloseableQueue):
     def _put(self, item):
         if self.fail_next_put:
             self.fail_next_put = False
-            raise FailingQueueException, "You Lose"
+            raise FailingQueueException("You Lose")
         return CloseableQueue._put(self, item)
     def _get(self):
         if self.fail_next_get:
             self.fail_next_get = False
-            raise FailingQueueException, "You Lose"
+            raise FailingQueueException("You Lose")
         return CloseableQueue._get(self)
 
 class FailingCloseableQueueTest(FailingQueueTest):
@@ -252,7 +252,7 @@ class CloseableQueueTest(unittest.TestCase, BlockingTestMixin):
         self.cum = 0
         for i in (0,1):
             threading.Thread(target=self.worker, args=(q,)).start()
-        for i in xrange(100):
+        for i in range(100):
             q.put(i)
         q.close()
         q.join()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -256,8 +256,8 @@ class CloseableQueueTest(unittest.TestCase, BlockingTestMixin):
             q.put(i)
         q.close()
         q.join()
-        self.assertEquals(self.cum, sum(range(100)),
-                          "q.join() did not block until all tasks were done")
+        self.assertEqual(self.cum, sum(range(100)),
+                         "q.join() did not block until all tasks were done")
         try:
             for i in (0,1):
                 q.put(None)         # instruct the threads to close

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -99,16 +99,16 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
                             LifoQueue = [222, 333, 111],
                             PriorityQueue = [111, 222, 333])
         actual_order = [q.get(), q.get(), q.get()]
-        self.assertEquals(actual_order, target_order[q.__class__.__name__],
-                          "Didn't seem to queue the correct data!")
+        self.assertEqual(actual_order, target_order[q.__class__.__name__],
+                         "Didn't seem to queue the correct data!")
         for i in range(QUEUE_SIZE-1):
             q.put(i)
-            self.assert_(not q.empty(), "Queue should not be empty")
-        self.assert_(not q.full(), "Queue should not be full")
+            self.assertTrue(not q.empty(), "Queue should not be empty")
+        self.assertTrue(not q.full(), "Queue should not be full")
         last = 2 * QUEUE_SIZE
         full = 3 * 2 * QUEUE_SIZE
         q.put(last)
-        self.assert_(q.full(), "Queue should be full")
+        self.assertTrue(q.full(), "Queue should be full")
         try:
             q.put(full, block=0)
             self.fail("Didn't appear to block with a full queue")
@@ -125,7 +125,7 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
         # Empty it
         for i in range(QUEUE_SIZE):
             q.get()
-        self.assert_(q.empty(), "Queue should be empty")
+        self.assertTrue(q.empty(), "Queue should be empty")
         try:
             q.get(block=0)
             self.fail("Didn't appear to block with an empty queue")
@@ -158,8 +158,8 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
         for i in range(100):
             q.put(i)
         q.join()
-        self.assertEquals(self.cum, sum(range(100)),
-                          "q.join() did not block until all tasks were done")
+        self.assertEqual(self.cum, sum(range(100)),
+                         "q.join() did not block until all tasks were done")
         for i in (0,1):
             q.put(-1)           # instruct the threads to close
         q.join()                # verify that you can join twice
@@ -247,7 +247,7 @@ class FailingQueueTest(unittest.TestCase, BlockingTestMixin):
         except FailingQueueException:
             pass
         q.put("last")
-        self.assert_(q.full(), "Queue should be full")
+        self.assertTrue(q.full(), "Queue should be full")
         # Test a failing blocking put
         q.fail_next_put = True
         try:
@@ -269,17 +269,17 @@ class FailingQueueTest(unittest.TestCase, BlockingTestMixin):
         # Check the Queue isn't damaged.
         # put failed, but get succeeded - re-add
         q.put("last")
-        self.assert_(q.full(), "Queue should be full")
+        self.assertTrue(q.full(), "Queue should be full")
         q.get()
-        self.assert_(not q.full(), "Queue should not be full")
+        self.assertTrue(not q.full(), "Queue should not be full")
         q.put("last")
-        self.assert_(q.full(), "Queue should be full")
+        self.assertTrue(q.full(), "Queue should be full")
         # Test a blocking put
         self.do_blocking_test(q.put, ("full",), q.get, ())
         # Empty it
         for i in range(QUEUE_SIZE):
             q.get()
-        self.assert_(q.empty(), "Queue should be empty")
+        self.assertTrue(q.empty(), "Queue should be empty")
         q.put("first")
         q.fail_next_get = True
         try:
@@ -287,16 +287,16 @@ class FailingQueueTest(unittest.TestCase, BlockingTestMixin):
             self.fail("The queue didn't fail when it should have")
         except FailingQueueException:
             pass
-        self.assert_(not q.empty(), "Queue should not be empty")
+        self.assertTrue(not q.empty(), "Queue should not be empty")
         q.fail_next_get = True
         try:
             q.get(timeout=0.1)
             self.fail("The queue didn't fail when it should have")
         except FailingQueueException:
             pass
-        self.assert_(not q.empty(), "Queue should not be empty")
+        self.assertTrue(not q.empty(), "Queue should not be empty")
         q.get()
-        self.assert_(q.empty(), "Queue should be empty")
+        self.assertTrue(q.empty(), "Queue should be empty")
         q.fail_next_get = True
         try:
             self.do_exceptional_blocking_test(q.get, (), q.put, ('empty',),
@@ -305,9 +305,9 @@ class FailingQueueTest(unittest.TestCase, BlockingTestMixin):
         except FailingQueueException:
             pass
         # put succeeded, but get failed.
-        self.assert_(not q.empty(), "Queue should not be empty")
+        self.assertTrue(not q.empty(), "Queue should not be empty")
         q.get()
-        self.assert_(q.empty(), "Queue should be empty")
+        self.assertTrue(q.empty(), "Queue should be empty")
 
     def test_failing_queue(self):
         # Test to make sure a queue is functioning correctly.

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -1,6 +1,9 @@
 # Some simple queue module tests, plus some failure conditions
 # to ensure the Queue locks remain stable.
-import Queue
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 import sys
 import threading
 import time
@@ -87,7 +90,7 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
 
     def simple_queue_test(self, q):
         if not q.empty():
-            raise RuntimeError, "Call this function with an empty queue"
+            raise RuntimeError("Call this function with an empty queue")
         # I guess we better check things actually queue correctly a little :)
         q.put(111)
         q.put(333)
@@ -102,21 +105,23 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
             q.put(i)
             self.assert_(not q.empty(), "Queue should not be empty")
         self.assert_(not q.full(), "Queue should not be full")
-        q.put("last")
+        last = 2 * QUEUE_SIZE
+        full = 3 * 2 * QUEUE_SIZE
+        q.put(last)
         self.assert_(q.full(), "Queue should be full")
         try:
-            q.put("full", block=0)
+            q.put(full, block=0)
             self.fail("Didn't appear to block with a full queue")
         except Queue.Full:
             pass
         try:
-            q.put("full", timeout=0.01)
+            q.put(full, timeout=0.01)
             self.fail("Didn't appear to time-out with a full queue")
         except Queue.Full:
             pass
         # Test a blocking put
-        self.do_blocking_test(q.put, ("full",), q.get, ())
-        self.do_blocking_test(q.put, ("full", True, 10), q.get, ())
+        self.do_blocking_test(q.put, (full,), q.get, ())
+        self.do_blocking_test(q.put, (full, True, 10), q.get, ())
         # Empty it
         for i in range(QUEUE_SIZE):
             q.get()
@@ -139,7 +144,7 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
     def worker(self, q):
         while True:
             x = q.get()
-            if x is None:
+            if x < 0:
                 q.task_done()
                 return
             with self.cumlock:
@@ -150,13 +155,13 @@ class BaseQueueTest(unittest.TestCase, BlockingTestMixin):
         self.cum = 0
         for i in (0,1):
             threading.Thread(target=self.worker, args=(q,)).start()
-        for i in xrange(100):
+        for i in range(100):
             q.put(i)
         q.join()
         self.assertEquals(self.cum, sum(range(100)),
                           "q.join() did not block until all tasks were done")
         for i in (0,1):
-            q.put(None)         # instruct the threads to close
+            q.put(-1)           # instruct the threads to close
         q.join()                # verify that you can join twice
 
     def test_queue_task_done(self):
@@ -213,19 +218,19 @@ class FailingQueue(Queue.Queue):
     def _put(self, item):
         if self.fail_next_put:
             self.fail_next_put = False
-            raise FailingQueueException, "You Lose"
+            raise FailingQueueException("You Lose")
         return Queue.Queue._put(self, item)
     def _get(self):
         if self.fail_next_get:
             self.fail_next_get = False
-            raise FailingQueueException, "You Lose"
+            raise FailingQueueException("You Lose")
         return Queue.Queue._get(self)
 
 class FailingQueueTest(unittest.TestCase, BlockingTestMixin):
 
     def failing_queue_test(self, q):
         if not q.empty():
-            raise RuntimeError, "Call this function with an empty queue"
+            raise RuntimeError("Call this function with an empty queue")
         for i in range(QUEUE_SIZE-1):
             q.put(i)
         # Test a failing non-blocking put.

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -1,4 +1,5 @@
 """Supporting definitions for the Python regression tests."""
+from __future__ import print_function
 
 if __name__ != 'test.test_support':
     raise ImportError('test_support must be imported from the test package')
@@ -95,7 +96,7 @@ def unlink(filename):
 def rmtree(path):
     try:
         shutil.rmtree(path)
-    except OSError, e:
+    except (OSError) as e:
         # Unix returns ENOENT, Windows returns ESRCH.
         if e.errno not in (errno.ENOENT, errno.ESRCH):
             raise
@@ -289,10 +290,10 @@ else:
             except UnicodeEncodeError:
                 pass
             else:
-                print \
+                print(\
                 'WARNING: The filename %r CAN be encoded by the filesystem.  ' \
                 'Unicode filename tests may not be effective' \
-                % TESTFN_UNICODE_UNENCODEABLE
+                % TESTFN_UNICODE_UNENCODEABLE)
 
 # Make sure we can write to TESTFN, try in /tmp if we can't
 fp = None
@@ -763,7 +764,7 @@ def run_doctest(module, verbosity=None):
     finally:
         sys.stdout = save_stdout
     if verbose:
-        print 'doctest (%s) ... %d tests with zero failures' % (module.__name__, t)
+        print('doctest (%s) ... %d tests with zero failures' % (module.__name__, t))
     return f, t
 
 #=======================================================================


### PR DESCRIPTION
This pull request includes changes that enable using CloseableQueue under both Python 2 and Python 3.  The changes to the `CloseableQueue` module itself are limited to import fixes and elimination of a `DeprecationWarning`.  The test changes bring the test cases in line with the most current version of the test suite.  The changes are described in a little more detail under each commit.

These changes were tested on Linux under Python 2.7.15, Python 3.6.0, and Python 3.7.2.  All tests passed without warnings.

Tests were executed via `python setup.py test`.